### PR TITLE
Fall back to CSIDL_LOCAL_APPDATA under taint on Windows

### DIFF
--- a/t/mktemp.t
+++ b/t/mktemp.t
@@ -16,7 +16,7 @@ ok(1);
 # MKSTEMP - test
 
 # Create file in temp directory
-my $template = File::Spec->catfile(File::Spec->tmpdir, 'wowserXXXX');
+my $template = File::Spec->catfile(File::Temp::_wrap_file_spec_tmpdir(), 'wowserXXXX');
 
 (my $fh, $template) = mkstemp($template);
 
@@ -87,7 +87,7 @@ if ($status) {
 # MKDTEMP
 # Temp directory
 
-$template = File::Spec->catdir(File::Spec->tmpdir, 'tmpdirXXXXXX');
+$template = File::Spec->catdir(File::Temp::_wrap_file_spec_tmpdir(), 'tmpdirXXXXXX');
 
 my $tmpdir = mkdtemp($template);
 
@@ -101,7 +101,7 @@ rmtree($tmpdir);
 # MKTEMP
 # Just a filename, not opened
 
-$template = File::Spec->catfile(File::Spec->tmpdir, 'mytestXXXXXX');
+$template = File::Spec->catfile(File::Temp::_wrap_file_spec_tmpdir(), 'mytestXXXXXX');
 
 my $tmpfile = mktemp($template);
 

--- a/t/security.t
+++ b/t/security.t
@@ -77,7 +77,7 @@ sub test_security {
   # Create the tempfile
   my $template = "tmpXXXXX";
   my ($fh1, $fname1) = eval { tempfile ( $template, 
-				  DIR => File::Spec->tmpdir,
+				  DIR => File::Temp::_wrap_file_spec_tmpdir(),
 				  UNLINK => 1,
 				);
 			    };
@@ -89,7 +89,7 @@ sub test_security {
         push(@files, $fname1); # store for end block
     } elsif (File::Temp->safe_level() != File::Temp::STANDARD) {
         chomp($@);
-        my $msg = File::Spec->tmpdir() . " possibly insecure: $@";
+        my $msg = File::Temp::_wrap_file_spec_tmpdir() . " possibly insecure: $@";
         skip $msg, 2; # one here and one in END
     } else {
         ok(0);

--- a/t/tempfile.t
+++ b/t/tempfile.t
@@ -154,7 +154,7 @@ push( @still_there, File::Spec->rel2abs($tempfile) ); # check at END
 #    on NFS
 # Try to do what we can.
 # Tempfile croaks on error so we need an eval
-$fh = eval { tempfile( 'ftmpXXXXX', DIR => File::Spec->tmpdir ) };
+$fh = eval { tempfile( 'ftmpXXXXX', DIR => File::Temp::_wrap_file_spec_tmpdir() ) };
 
 if ($fh) {
 


### PR DESCRIPTION
When File::Spec->tmpdir gives an unwritable directory on Windows when
in taint mode, this attempts to use a directory in the local appdata
folder instead.

See https://rt.cpan.org/Ticket/Display.html?id=60340

