### PR TITLE
faster fork.t

### DIFF
--- a/t/fork.t
+++ b/t/fork.t
@@ -38,8 +38,7 @@ for my $i (1 .. $children) {
   } else {
     # in a child we can't keep the count properly so we do it manually
     # make sure that child 1 dies first
-    srand();
-    my $time = (($i-1) * 5) +int(rand(5));
+    my $time = ($i-1) * 3;
     print "# child $i sleeping for $time seconds\n";
     sleep($time);
     my $count = $i + 1;
@@ -72,8 +71,7 @@ for my $i (1 .. $children) {
     # parent process
     next;
   } else {
-    srand();
-    my $time = (($i-1) * 5) +int(rand(5));
+    my $time = ($i-1) * 3;
     print "# child $i sleeping for $time seconds\n";
     sleep($time);
     my $count = 5 + $i;


### PR DESCRIPTION
Reduce the time between starting the 2nd child after the 1st one from
5s to 3s, and remove the unnecessary random & constant sleep at the
beginning. The overall sleep time is now 6s, previously the average
sleep time was 14s and the worst sleep time 18s.