### PR TITLE
Skip write permissions test when running as root.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
 {{$NEXT}}
+          - Update new file permissions test to account for root permissions behavior.
 
 0.2310    2020-09-26 17:37:56Z
           - add AppVeyor CI

--- a/t/tempfile.t
+++ b/t/tempfile.t
@@ -123,7 +123,7 @@ push(@files, File::Spec->rel2abs($tempfile));
 #
 # So don't check actual file permissions -- it will be 0444 on Win32
 # instead of 0400.  Instead, just check that no longer writable.
-ok( (-f $tempfile && -r _ && ! -w _),
+ok( (-f $tempfile && -r _ && ($> ? !-w _ : -w _)),
     "Created tempfile with changed permissions" );
 push(@files, File::Spec->rel2abs($tempfile));
 


### PR DESCRIPTION
root processes can ignore file permissions so this test cannot be run as root.

This also addresses https://github.com/Perl/perl5/issues/18172 and https://rt.cpan.org/Ticket/Display.html?id=133443