### PR TITLE
Don't use $1 blindly in File::Temp->tempdir

### DIFF
--- a/lib/File/Temp.pm
+++ b/lib/File/Temp.pm
@@ -1705,8 +1705,8 @@ sub tempdir  {
   # Create the directory
   my $tempdir;
   my $suffixlen = 0;
-  if ($^O eq 'VMS') {           # dir names can end in delimiters
-    $template =~ m/([\.\]:>]+)$/;
+  if ($^O eq 'VMS'
+      && ($template =~ m/([\.\]:>]+)$/)) {  # dir specs can end in delimiters
     $suffixlen = length($1);
   }
   if ( ($^O eq 'MacOS') && (substr($template, -1) eq ':') ) {


### PR DESCRIPTION
On VMS only there is some very old code that has been making blind
use of $1 without knowing if the match succeeded. If $1 happens to
be empty when the match fails, no harm is done, but if it has a
value in it whose length is longer than the position of the final
'X' in the template pattern, _gettemp ends up with a negative
offset and things go off the rails.  ext/File-Find/t/taint.t has
been failing in core because of this.